### PR TITLE
Adiciona matrículas no Google Calendar

### DIFF
--- a/ajax/google_calendar.php
+++ b/ajax/google_calendar.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace GDE;
+
+define('NO_CACHE', true);
+define('NO_HTML', true);
+define('NO_REDIRECT', true);
+
+require_once('../common/common.inc.php');
+
+$ra = (isset($_POST['ra'])) ? intval($_POST['ra']) : -1;
+$Periodo_Selecionado = isset($_POST['periodo']) && ($_POST['periodo'] > 0) ? Periodo::Load($_POST['periodo']) : Periodo::getAtual();
+$nivel = (isset($_GET['n'])) ? $_GET['n'][0] : 'G';
+
+$nomeCalendario = $_POST['nomeCalendario'];
+$idCalendario = $_POST['idCalendario'];
+$datasImportantes = $_POST['datasImportantes'];
+
+
+
+// Client da API
+$Calendar = new GooglCalendar;
+
+// Se nao temos o token, deu ruim
+if (empty($_SESSION['token'])) {
+  echo "Sem token";
+} else {
+
+  $Calendar->setTokenAcesso('', $_SESSION['token']);
+
+
+  // Servico da API do Calendar
+  $Calendar->setServico();
+
+  // Se precisa criar um calendario
+  if ($idCalendario === '') {
+    $idCalendario = $Calendar->criaCalendario($nomeCalendario);
+  }
+
+
+  $Aluno = ($ra > 0) ? Aluno::Load($ra) : $_Usuario->getAluno(true);
+  $Horario = $Aluno->Monta_Horario($Periodo_Selecionado->getPeriodo(), $nivel);
+
+
+  $Calendar->adicionaHorario($idCalendario, $Horario, $Periodo_Selecionado);
+  if ($datasImportantes) {
+    $Calendar->adicionaCalendarioUnicamp($idCalendario, $Periodo_Selecionado);
+  }
+
+  // reseta o token
+  unset($_SESSION['token']);
+}
+
+
+
+
+
+
+
+
+
+?>

--- a/ajax/horario.php
+++ b/ajax/horario.php
@@ -89,7 +89,7 @@ $limpos = Util::Horarios_Livres($Horario);
 		<th align="center"><strong>Sexta</strong></th>
 		<th align="center"><strong>S&aacute;bado</strong></th>
 	</tr>
-<?php			
+<?php
 for($j = 7; $j < 23; $j++) {
 	if(in_array($j, $limpos))
 		continue;
@@ -118,6 +118,9 @@ if($_tipo == 'A') {
 	</tr>
 	<tr>
 		<td colspan="7" align="center" style="padding: 10px;"><a href="#" onclick="window.open('<?= CONFIG_URL; ?>imprimir-horario/?ra=<?= $Aluno->getRA(true); ?>&p=<?= $Periodo_Selecionado->getID(true); ?>&n=<?= $nivel; ?>', '_blank', 'width=700, height=550, scrollbars=yes'); return false;">Visualizar Para Impress&atilde;o</a></td>
+	</tr>
+	<tr>
+		<td colspan="7" align="center" style="padding: 10px;"><a href="#" onclick="window.open('<?= CONFIG_URL; ?>google-calendar/?ra=<?= $Aluno->getRA(true); ?>&p=<?= $Periodo_Selecionado->getID(true); ?>&n=<?= $nivel; ?>', '_blank', 'width=700, height=550, scrollbars=yes'); return false;">Adicionar ao Google Calendar</a></td>
 	</tr>
 <?php } if($_tipo == 'P') {
 ?>

--- a/classes/GDE/GooglCalendar.inc.php
+++ b/classes/GDE/GooglCalendar.inc.php
@@ -50,6 +50,7 @@ class GooglCalendar{
     $this->client->setAuthConfig(self::URL_CREDENCIAIS);
     $this->client->setAccessType('offline');
     $this->client->setRedirectUri(self::URL_REDIRECIONAMENTO);
+		$this->client->setState($estado);
 	}
 
 

--- a/classes/GDE/GooglCalendar.inc.php
+++ b/classes/GDE/GooglCalendar.inc.php
@@ -139,7 +139,60 @@ class GooglCalendar{
 	 * Adiciona o calendario da UNICAMP no Calendar
 	 */
 	public function adicionaCalendarioUnicamp($idCalendario, $Periodo_Selecionado){
+		$ano = explode(' ', $Periodo_Selecionado->getNome())[0];
 
+		$this->criarEventoAllDay($idCalendario, $Periodo_Selecionado->getDataDesistencia(),	$ano, 'Último dia para desistência de disciplinas');
+		$this->criarEventoAllDay($idCalendario, $Periodo_Selecionado->getDataSemanaDeEstudos(), $ano, 'Semana de estudos');
+		$this->criarEventoAllDay($idCalendario, $Periodo_Selecionado->getDataExames(), $ano, 'Semana de exames');
+		$this->criarEventoAllDay($idCalendario, $Periodo_Selecionado->getDataMatricula(), $ano, 'Período de matriculas');
+		$this->criarEventoAllDay($idCalendario, $Periodo_Selecionado->getDataAlteracao(), $ano, 'Período de alteração de matriculas');
+	}
+
+	/**
+	 * criarEventoAllDay
+	 *
+	 * Cria um evento de dia todo
+	 * @return Event_id
+	 */
+	private function criarEventoAllDay($idCalendario, $data, $ano, $nome) {
+		if (strlen($data) > 5) { // se são vários dias
+			$primeiro = explode('-', $data)[0];
+			$ultimo = explode('-', $data)[1];
+		} else { // se é só 1
+			$primeiro = $data;
+			$ultimo = $data;
+		}
+
+		$data_inicio = explode('/', $primeiro);
+		$data_termino = explode('/', $ultimo);
+		$inicio = $this->criaDataDia($ano, $data_inicio[1], $data_inicio[0]);
+		$termino = $this->criaDataDia($ano, $data_termino[1], $data_termino[0]);
+
+		$evento = new Google_Service_Calendar_Event(array(
+			'summary' => $nome,
+			'location' => '',
+			'start' => array(
+				'date' => $inicio,
+				'timeZone' => self::FUSO_HORARIO,
+			),
+			'end' => array(
+				'date' => $termino,
+				'timeZone' => self::FUSO_HORARIO,
+			),
+			'reminders' => array(
+				'useDefault' => FALSE,
+			),
+		));
+		return $this->servico->events->insert($idCalendario, $evento);
+	}
+
+	/**
+	 * criaDataDia
+	 *
+	 * @return string com data no formato para eventos de dia todo (all-day)
+	 */
+	private function criaDataDia($ano, $mes, $dia){
+		return date("Y-m-d", mktime(0, 0, 0, $mes, $dia, $ano));
 	}
 
 	/**

--- a/classes/GDE/GooglCalendar.inc.php
+++ b/classes/GDE/GooglCalendar.inc.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace GDE;
+
+
+require_once('../vendor/autoload.php');
+use Google_Client;
+use Google_Service_Calendar;
+use Google_Service_Calendar_Calendar;
+use Google_Service_Calendar_Event;
+use DateTime;
+
+/**
+ * GooglCalendar
+ *
+ */
+class GooglCalendar{
+	/**
+	 * @var Google_Client
+	 *
+	 */
+	protected $client;
+
+	/**
+	 * @var Google_Service_Calendar
+	 *
+	 */
+	protected $servico;
+
+  /**
+	 * @var string
+	 *
+	 */
+	protected $tokenAcesso;
+
+
+
+
+
+	// Constantes
+	const URL_CREDENCIAIS = '../credenciais.json'; // FIXME Colocar em um lugar melhor
+  const URL_REDIRECIONAMENTO = CONFIG_URL .'views/google-calendar.php';
+  const BATCH_LIMITE = 50;
+
+
+	public function __construct($estado = '') {
+		$this->client = new Google_Client();
+    $this->client->setApplicationName('GDE');
+    $this->client->setScopes(Google_Service_Calendar::CALENDAR);
+    $this->client->setAuthConfig(self::URL_CREDENCIAIS);
+    $this->client->setAccessType('offline');
+    $this->client->setRedirectUri(self::URL_REDIRECIONAMENTO);
+	}
+
+
+  /**
+   * setTokenAutenticacao
+   *
+   * redireciona para a pagina de autenticacao do Google
+   */
+  public function setTokenAutenticacao(){
+    // Pede a autorizacao do usuario
+    $authUrl = $this->client->createAuthUrl();
+    header('Location: ' . filter_var($authUrl, FILTER_SANITIZE_URL));
+  }
+
+
+  /**
+   * setTokenAcesso
+   *
+   * param: tokenAutenticacao
+   * @return accessToken
+   */
+  public function setTokenAcesso($codigo, $token = ''){
+    if (empty($token)){
+      // Exchange authorization code for an access token.
+      $accessToken = $this->client->fetchAccessTokenWithAuthCode($codigo);
+
+      // Check to see if there was an error.
+      if (array_key_exists('error', $accessToken)) {
+          throw new Exception(join(', ', $accessToken));
+      }
+    } else {
+			$accessToken = $token;
+		}
+
+    $this->client->setAccessToken($accessToken);
+
+    // Refresh the token if it's expired.
+    if ($this->client->isAccessTokenExpired()) {
+        $this->client->fetchAccessTokenWithRefreshToken($this->client->getRefreshToken());
+    }
+		return $accessToken;
+  }
+
+  /**
+   * setServico
+   *
+   *
+   * @return Google_Service_Calendar
+   */
+  public function setServico(){
+    if (!empty($this->client)){
+      $this->servico = new Google_Service_Calendar($this->client);
+    }
+  }
+
+  /**
+   * getCalendarios
+   *
+   * Devolve a lista de calendarios do usuario
+   * @return Calendar_List
+   */
+  public function getCalendarios(){
+    $listaCalendarios = $this->servico->calendarList->listCalendarList();
+    return $listaCalendarios;
+  }
+}

--- a/classes/GDE/GooglCalendar.inc.php
+++ b/classes/GDE/GooglCalendar.inc.php
@@ -38,9 +38,9 @@ class GooglCalendar{
 
 
 	// Constantes
+	const FUSO_HORARIO = 'America/Sao_Paulo';
 	const URL_CREDENCIAIS = '../credenciais.json'; // FIXME Colocar em um lugar melhor
   const URL_REDIRECIONAMENTO = CONFIG_URL .'views/google-calendar.php';
-  const BATCH_LIMITE = 50;
 
 
 	public function __construct($estado = '') {
@@ -116,4 +116,39 @@ class GooglCalendar{
     $listaCalendarios = $this->servico->calendarList->listCalendarList();
     return $listaCalendarios;
   }
+
+	/**
+	 * criaCalendario
+	 *
+	 * Cria um novo calendario para o usuario
+	 * @return Calendar_ID
+	 */
+	public function criaCalendario($nome){
+		$calendario = new Google_Service_Calendar_Calendar();
+		$calendario->setSummary($nome);
+		$calendario->setTimeZone(self::FUSO_HORARIO);
+
+		$calendarioNovo = $this->servico->calendars->insert($calendario);
+
+		return $calendarioNovo->getId();
+	}
+
+	/**
+	 * adicionaCalendarioUnicamp
+	 *
+	 * Adiciona o calendario da UNICAMP no Calendar
+	 */
+	public function adicionaCalendarioUnicamp($idCalendario, $Periodo_Selecionado){
+
+	}
+
+	/**
+   * adicionaHorario
+   *
+   * Cria os eventos das aulas no Calendario escolhido
+   * @return null
+   */
+  public function adicionaHorario($idCalendario, $Horario, $Periodo_Selecionado){
+
+	}
 }

--- a/classes/GDE/Periodo.inc.php
+++ b/classes/GDE/Periodo.inc.php
@@ -37,6 +37,56 @@ class Periodo extends Base {
 	 */
 	protected $tipo = self::TIPO_NORMAL;
 
+	/**
+	 * @var string
+	 *
+	 * @ORM\Column(type="string", nullable=true)
+	 */
+	protected $data_inicio_aulas;
+
+	/**
+	 * @var string
+	 *
+	 * @ORM\Column(type="string", nullable=true)
+	 */
+	protected $data_fim_aulas;
+
+	/**
+	 * @var string
+	 *
+	 * @ORM\Column(type="string", nullable=true)
+	 */
+	protected $data_desistencia;
+
+	/**
+	 * @var string
+	 *
+	 * @ORM\Column(type="string", nullable=true)
+	 */
+	protected $data_semana_estudos;
+
+	/**
+	* @var string
+	*
+	* @ORM\Column(type="string", nullable=true)
+	*/
+	protected $data_exames;
+
+	/**
+	 * @var string
+	 *
+	 * @ORM\Column(type="string", nullable=true)
+	 */
+	protected $data_matricula;
+
+	/**
+	 * @var string
+	 *
+	 * @ORM\Column(type="string", nullable=true)
+	 */
+	protected $data_alteracao;
+
+
 	const PERIODO_DESCONHECIDO = 'Desconhecido';
 	const PERIODO_DESCONHECIDO_DAC = '??????';
 
@@ -70,7 +120,7 @@ class Periodo extends Base {
 	}
 
 	/**
-	 * getNOme
+	 * getNome
 	 *
 	 * Retorna o nome deste periodo
 	 *
@@ -90,6 +140,100 @@ class Periodo extends Base {
 		return ((substr($this->id_periodo, -1) != 0)
 			? substr($this->id_periodo, -1).'S'
 			: 'VE').substr($this->id_periodo, 0, 4);
+	}
+
+	/**
+	 * getInicioAulas
+	 *
+	 * Retorna a data do inicio deste periodo
+	 *
+	 * @return string
+	 */
+	public function getInicioAulas() {
+		return $this->data_inicio_aulas;
+	}
+
+	/**
+	 * getFimAulas
+	 *
+	 * Retorna a data do fim deste periodo
+	 *
+	 * @return string
+	 */
+	public function getFimAulas() {
+		return $this->data_fim_aulas;
+	}
+
+	/**
+	 * getDataDesistencia
+	 *
+	 * Retorna a data do ultimo dia para desistencia de disciplinas
+	 *
+	 * @return string
+	 */
+	public function getDataDesistencia() {
+		return $this->data_desistencia;
+	}
+
+	/**
+	 * getDataSemanaDeEstudos
+	 *
+	 * Retorna a data da semana de estudos
+	 *
+	 * @return string
+	 */
+	public function getDataSemanaDeEstudos() {
+		return $this->data_semana_estudos;
+	}
+
+	/**
+	 * getDataExames
+	 *
+	 * Retorna a data dos exames
+	 *
+	 * @return string
+	 */
+	public function getDataExames() {
+		return $this->data_exames;
+	}
+
+	/**
+	 * getDataMatricula
+	 *
+	 * Retorna a data da matricula do proximo semestre
+	 *
+	 * @return string
+	 */
+	public function getDataMatricula() {
+		return $this->data_matricula;
+	}
+
+	/**
+	 * getFimAulas
+	 *
+	 * Retorna a data da alteracao de matricula do proximo semestre
+	 *
+	 * @return string
+	 */
+	public function getDataAlteracao() {
+		return $this->data_alteracao;
+	}
+
+	/**
+	 * getDatasImportantesHTML
+	 *
+	 * Cria uma lista
+	 *
+	 * @return string
+	 */
+	public function getDatasImportantesHTML() {
+		$ano = explode(' ', $this->nome)[0];
+		$semestre = explode(' ', $this->nome)[2][0];
+		echo '<li>'.$this->getDataDesistencia().' - Último dia para desistência de matrícula em disciplinas</li>';
+		echo '<li>'.$this->getDataSemanaDeEstudos().' - Semana de estudos</li>';
+		echo '<li>'.$this->getDataExames().' - Exames Finais</li>';
+		echo '<li>'.$this->getDataMatricula().' - Matrícula em disciplinas do próximo semestre</li>';
+		echo '<li>'.$this->getDataAlteracao().' - Alteração de matrícula em disciplinas do próximo semestre</li>';
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "doctrine/dbal": "^2.7 || 2.5.13",
     "doctrine/common": "^2.8 || 2.7.3",
     "predis/predis": "^1.1",
-    "ircmaxell/password-compat": "^1.0"
+    "ircmaxell/password-compat": "^1.0",
+    "google/apiclient": "^2.0"
   },
   "suggest": {
     "ext-mysqli": "*",

--- a/views/google-calendar.php
+++ b/views/google-calendar.php
@@ -1,13 +1,28 @@
 <?php
- namespace GDE;
- define('NO_HTML', true);
-define('TITULO', false);
- require_once('../common/common.inc.php');
- $ra = (isset($_GET['ra'])) ? intval($_GET['ra']) : -1;
-$p = (isset($_GET['p'])) ? intval($_GET['p']) : null;
-$n = (isset($_GET['n'])) ? $_GET['n'][0] : 'G';
 
-$Calendar = new GooglCalendar;
+namespace GDE;
+
+define('NO_HTML', true);
+define('TITULO', false);
+
+require_once('../common/common.inc.php');
+
+if (isset($_GET['state'])) {
+  $state = explode(",", $_GET['state']);
+  $ra = $state[0];
+  $p = $state[1];
+  $n = $state[2];
+} else {
+  $ra = (isset($_GET['ra'])) ? intval($_GET['ra']) : -1;
+  $p = (isset($_GET['p'])) ? intval($_GET['p']) : null;
+  $n = (isset($_GET['n'])) ? $_GET['n'][0] : 'G';
+}
+
+$estado = $ra.','.$p.','.$n;
+
+
+// Client da API
+$Calendar = new GooglCalendar($estado);
 
 // Se nao temos o codigo, pedimos um
 if (!isset($_GET['code']) && empty($_GET['error'])) {
@@ -82,7 +97,7 @@ if (!isset($_GET['code']) && empty($_GET['error'])) {
         <br>
         <script type="text/javascript">
           function adicionaNoCalendar() {
-            alert("Clicou")
+            alert("Clicou");
           }
         </script>
 

--- a/views/google-calendar.php
+++ b/views/google-calendar.php
@@ -1,23 +1,56 @@
 <?php
-
-namespace GDE;
-
-define('NO_HTML', true);
+ namespace GDE;
+ define('NO_HTML', true);
 define('TITULO', false);
-
-
-require_once('../common/common.inc.php');
-
-
-$ra = (isset($_GET['ra'])) ? intval($_GET['ra']) : -1;
+ require_once('../common/common.inc.php');
+ $ra = (isset($_GET['ra'])) ? intval($_GET['ra']) : -1;
 $p = (isset($_GET['p'])) ? intval($_GET['p']) : null;
 $n = (isset($_GET['n'])) ? $_GET['n'][0] : 'G';
 
 
-?>
+ ?>
 <html>
+<link rel="stylesheet" href="<?= CONFIG_URL; ?>web/css/gde.css?<?= REVISION; ?>" type="text/css" />
 <head>
 </head>
 <body style="padding: 20px;">
+  <div style="background-color: #FFFFFF; margin: 0 auto; width: auto; text-align: left;">
+    <div id="content_bg">
+      <div style="padding: 20px 15px 20px 15px; width:auto;">
+        <h1 id="anoPeriodo"><?= $Periodo_Selecionado->getNome(false); ?></h1>
+        <br>
+        <h3>Selecione um Calend&aacute;rio existente ou digite algum nome para criar um novo</h3>
+        <br>
+        <br>
+        <div>
+          <div style="float: left;">
+            <select id='select-id-calendario'>
+              <!-- TODO colocar calendarios do usuario aqui -->
+            </select>
+          </div>
+          <div style="float: left; padding-left: 30px;">
+            <input id='input-novo-calendario' type="text" placeholder="Nome do calendário"/>
+          </div>
+        </div>
+
+        <br><br>
+        <div style="clear:both;">
+          <input type="checkbox" id="checkbox-datas-importantes">Adicionar datas do calendário da UNICAMP</input>
+          <ul id='calendario-unicamp'>
+            <!-- TODO colocar datas importantes aqui -->
+          </ul>
+        </div>
+        <br>
+        <br>
+        <script type="text/javascript">
+          function adicionaNoCalendar() {
+            alert("Clicou")
+          }
+        </script>
+
+        <button type="button" onclick="adicionaNoCalendar()">Adicionar hor&aacute;rios no calend&aacute;rio</button>
+      </div>
+    </div>
+  </div>
 </body>
 <html>

--- a/views/google-calendar.php
+++ b/views/google-calendar.php
@@ -37,7 +37,7 @@ $n = (isset($_GET['n'])) ? $_GET['n'][0] : 'G';
         <div style="clear:both;">
           <input type="checkbox" id="checkbox-datas-importantes">Adicionar datas do calendário da UNICAMP</input>
           <ul id='calendario-unicamp'>
-            <!-- TODO colocar datas importantes aqui -->
+            <?php $Periodo_Selecionado->getDatasImportantesHTML(); ?>
           </ul>
         </div>
         <br>

--- a/views/google-calendar.php
+++ b/views/google-calendar.php
@@ -41,7 +41,8 @@ if (!isset($_GET['code']) && empty($_GET['error'])) {
     echo "<h1>Não será possível criar os horários sem autorização</h1>";
   } else {
 
-    $Calendar->setTokenAcesso($_GET['code']);
+    // coloca o token na sessao para usar na insercao
+    $_SESSION['token'] = $Calendar->setTokenAcesso($_GET['code']);
 
     // Servico da API do Calendar
     $Calendar->setServico();
@@ -97,7 +98,39 @@ if (!isset($_GET['code']) && empty($_GET['error'])) {
         <br>
         <script type="text/javascript">
           function adicionaNoCalendar() {
-            alert("Clicou");
+            let ra = <?php echo $ra; ?>;
+            let periodo = <?php echo $p; ?>;
+            let nivel = '<?php echo $n; ?>';
+
+            let select = document.getElementById('select-id-calendario')
+            let idCalendario = select[select.selectedIndex].value
+
+            let datasImportantes = $('#checkbox-datas-importantes').is(":checked")
+
+            let autorizou = true
+            let nomeCalendario = $('#input-novo-calendario').val()
+
+            if (nomeCalendario !== ''){
+              autorizou = confirm('Você deseja criar um calendario novo chamado "' + nomeCalendario + '"?')
+              idCalendario = ''
+            }
+
+            if (autorizou){
+              let parametros = { nivel: nivel, ra: ra, nomeCalendario: nomeCalendario, idCalendario: idCalendario, periodo: periodo, datasImportantes: datasImportantes }
+              $.post("<?= CONFIG_URL; ?>ajax/google_calendar.php", parametros,
+                function(data) {
+                  if(data) {
+                    console.log(data)
+                    alert("Algo deu errado")
+                  } else {
+                    alert("Seu horário foi adicionado ao Calendar")
+                  }
+                }
+              );
+            } else {
+              // alert('Se deseja usar um calendário já existente selecione-o sem digitar nada na caixa de texto')
+              document.getElementById('input-novo-calendario').value = ''
+            }
           }
         </script>
 

--- a/views/google-calendar.php
+++ b/views/google-calendar.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GDE;
+
+define('NO_HTML', true);
+define('TITULO', false);
+
+
+require_once('../common/common.inc.php');
+
+
+$ra = (isset($_GET['ra'])) ? intval($_GET['ra']) : -1;
+$p = (isset($_GET['p'])) ? intval($_GET['p']) : null;
+$n = (isset($_GET['n'])) ? $_GET['n'][0] : 'G';
+
+
+?>
+<html>
+<head>
+</head>
+<body style="padding: 20px;">
+</body>
+<html>

--- a/views/google-calendar.php
+++ b/views/google-calendar.php
@@ -32,6 +32,7 @@ if (!isset($_GET['code']) && empty($_GET['error'])) {
  ?>
 <html>
 <link rel="stylesheet" href="<?= CONFIG_URL; ?>web/css/gde.css?<?= REVISION; ?>" type="text/css" />
+<script type="text/javascript" src="<?= CONFIG_URL; ?>web/js/jquery-1.7.2.min.js"></script>
 <head>
 </head>
 <body style="padding: 20px;">
@@ -116,6 +117,7 @@ if (!isset($_GET['code']) && empty($_GET['error'])) {
             }
 
             if (autorizou){
+              // TODO colocar indicador de andamento (bolinha girando)
               let parametros = { nivel: nivel, ra: ra, nomeCalendario: nomeCalendario, idCalendario: idCalendario, periodo: periodo, datasImportantes: datasImportantes }
               $.post("<?= CONFIG_URL; ?>ajax/google_calendar.php", parametros,
                 function(data) {
@@ -125,6 +127,7 @@ if (!isset($_GET['code']) && empty($_GET['error'])) {
                   } else {
                     alert("Seu horário foi adicionado ao Calendar")
                   }
+                  //TODO TIRAR INDICADOR DE ANDAMENTO
                 }
               );
             } else {

--- a/views/google-calendar.php
+++ b/views/google-calendar.php
@@ -61,7 +61,13 @@ if (!isset($_GET['code']) && empty($_GET['error'])) {
     $meu = ($_Usuario->getAluno(true)->getID() == $Aluno->getID());
     $limpos = Util::Horarios_Livres($Horario);
   ?>
-  <div style="background-color: #FFFFFF; margin: 0 auto; width: auto; text-align: left;">
+  <div id="overlay" style="width: 100%; height: 100%; background-color: black; opacity: 0.7; display: none; padding: -20 -20 -20 -20; z-index: 1000; position: absolute; top: 0; left: 0;">
+    <div style="align: center; text-align: center; vertical-align: center; padding-top: 200px;">
+      <h1 style="align: center; text-align: center; vertical-align: center; font-size: 40px;">Processando...</h1>
+    </div>
+  </div>
+
+  <div style="background-color: #FFFFFF; margin: 0 auto; width: auto; text-align: left; position: absolute; top: 20;">
     <div id="content_bg">
       <div style="padding: 20px 15px 20px 15px; width:auto;">
         <h1 id="anoPeriodo"><?= $Periodo_Selecionado->getNome(false); ?></h1>
@@ -117,7 +123,7 @@ if (!isset($_GET['code']) && empty($_GET['error'])) {
             }
 
             if (autorizou){
-              // TODO colocar indicador de andamento (bolinha girando)
+              $('#overlay').show()
               let parametros = { nivel: nivel, ra: ra, nomeCalendario: nomeCalendario, idCalendario: idCalendario, periodo: periodo, datasImportantes: datasImportantes }
               $.post("<?= CONFIG_URL; ?>ajax/google_calendar.php", parametros,
                 function(data) {
@@ -126,10 +132,11 @@ if (!isset($_GET['code']) && empty($_GET['error'])) {
                     alert("Algo deu errado")
                   } else {
                     alert("Seu horário foi adicionado ao Calendar")
+                    window.close();
                   }
-                  //TODO TIRAR INDICADOR DE ANDAMENTO
                 }
               );
+              $('#overlay').hide()
             } else {
               // alert('Se deseja usar um calendário já existente selecione-o sem digitar nada na caixa de texto')
               document.getElementById('input-novo-calendario').value = ''


### PR DESCRIPTION
Resolve #37 
Agora há um botão embaixo de "Vizualizar Para Impressão" na aba Matrículas, que abre uma nova guia. Essa guia, após autenticar com a conta do Google leva à um menu com algumas opções para a adição no Calendar.

Vai ser necessário configurar a API do Google e adicionar alguns campos novos na tabela gde_periodos.
