### PR TITLE
Corrige link de amigo no planejador

### DIFF
--- a/ajax/planejador.php
+++ b/ajax/planejador.php
@@ -663,7 +663,7 @@ if($_POST['a'] == 'n') { // Nova Opcao
 		usort($Amigos, "\GDE\UsuarioAmigo::Order_Por_Nome_Sort");
 		$lista = array();
 		foreach($Amigos as $Amigo)
-			$lista[] = "<a href=\"Perfil.php?l=".$Amigo->getAmigo()->getLogin()."\" target=\"_blank\" style=\"text-decoration: none;\" title=\"".$Amigo->getAmigo()->getNome_Completo()."\">".$Amigo->Apelido_Ou_Nome(true, true)."</a>";
+			$lista[] = "<a href=\"<?= CONFIG_URL; ?>perfil/?usuario=".$Amigo->getAmigo()->getLogin()."\" target=\"_blank\" style=\"text-decoration: none;\" title=\"".$Amigo->getAmigo()->getNome_Completo()."\">".$Amigo->Apelido_Ou_Nome(true, true)."</a>";
 
 		$Ret = array(
 			'Amigos' => $lista,


### PR DESCRIPTION
No planejador, o link para o perfil de amigos, listados em uma disciplina planejada em comum, está incorreto.

O link redireciona para https://grade.daconline.unicamp.br/planejador/Perfil.php?l=username em vez de https://grade.daconline.unicamp.br/perfil/?usuario=username