### PR TITLE
Atualiza mapa (Issue #75)

### DIFF
--- a/views/mapa.php
+++ b/views/mapa.php
@@ -7,7 +7,7 @@ require_once('../common/common.inc.php');
 if(isset($_GET['cm']))
 	die("<img src='".CONFIG_URL."web/images/loading.gif' /> Carregando Mapa...");
 
-$link = "https://maps.google.com/maps/ms?ie=UTF8&msa=0&msid=207972918742334384558.00049b21f38a1896b2cc5&z=15&output=embed";
+$link = "https://www.google.com/maps/d/embed?mid=1P2EmRJ18yUjdKwqg8gbpLR0WGi3Kxug&ehbc=2E312F";
 
 ?>
 <script type="text/javascript">

--- a/views/sala.php
+++ b/views/sala.php
@@ -35,9 +35,9 @@ if($Sala->getID_Unidade() != null) {
 $mapa_encontrado = ($link != null);
 
 if($link != null)
-	$link = "http://maps.google.com/maps/ms?ie=UTF8&msa=0&msid=207972918742334384558.00049b21f38a1896b2cc5".$link."&z=17&output=embed";
+	$link = "https://www.google.com/maps/d/embed?mid=1P2EmRJ18yUjdKwqg8gbpLR0WGi3Kxug&ehbc=2E312F".$link;
 else
-	$link = "http://maps.google.com/maps/ms?ie=UTF8&msa=0&msid=207972918742334384558.00049b21f38a1896b2cc5&z=15&output=embed";
+	$link = "https://www.google.com/maps/d/embed?mid=1P2EmRJ18yUjdKwqg8gbpLR0WGi3Kxug&ehbc=2E312F";
 
 ?>
 


### PR DESCRIPTION
Essa alteração traz um novo mapa para resolver a Issue #75 com a atualização das informações dos institutos e restaurantes universitários. Também adicionamos todos os pontos de alimentação presentes no campus que foram retirados do [mapa oficial da Unicamp](https://prefeitura.unicamp.br/mapa-dos-pontos-comerciais/).

Além disso, também fizemos alterações no BD para renomearmos a sigla da Faculdade de Engenharia Civil, Arquitetura e Urbanismo de FEC para [FECFAU](https://www.fecfau.unicamp.br/) e adicionamos os links faltantes de mapa na tabela gde_institutos.

Essas são as alterações que fizemos no BD local e precisariam ser replicadas para o BD oficial:

```
update gde_institutos
set sigla = 'FECFAU'
where sigla = 'FEC';

update gde_institutos
set link_mapa = '&ll=-22.830229,-47.063774&spn=0.002912,0.005681&t=h&iwloc=00049b23143929e36988b&z=18'
where sigla = 'FENF';

update gde_institutos
set link_mapa = '&ll=-22.824077,-47.064054&spn=0.002912,0.005681&t=h&iwloc=00049b23143929e36988b&z=18'
where sigla = 'FCF';

update gde_institutos
set link_mapa = '&ll=-22.816366,-47.063264&spn=0.002912,0.005681&t=h&iwloc=00049b23143929e36988b&z=18'
where sigla = 'FECFAU';
``` 